### PR TITLE
feat: expose source-backed lexical tokens

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,26 @@ pub mod token;
 
 pub use error::Error;
 pub use parser::Parser;
+use token::Token;
+
+/// A lexical token and its range in the source text.
+///
+/// `start..end` is a half-open range whose offsets are measured in Unicode
+/// scalar values, the same coordinate system used by positions in [`ast`].
+/// Scanner-inserted semicolons are omitted because they have no source range.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LexicalToken {
+    pub start: usize,
+    pub end: usize,
+    pub token: Token,
+}
+
+/// Tokenize Go source and return each token with its source range.
+///
+/// Whitespace and scanner-inserted semicolons are not returned.
+pub fn tokenize_source<S: AsRef<str>>(source: S) -> anyhow::Result<Vec<LexicalToken>> {
+    scanner::Scanner::from(source).tokenize()
+}
 
 /// parse source code to `ast::File`
 pub fn parse_source<S: AsRef<str>>(source: S) -> anyhow::Result<ast::File> {

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -200,22 +200,13 @@ impl Scanner {
 
     pub(crate) fn tokenize(mut self) -> Result<Vec<LexicalToken>> {
         let mut tokens = Vec::new();
-        while let Some(token) = self.next_source_token()? {
-            tokens.push(token);
+        while let Some((start, token)) = self.next_token()? {
+            let end = self.position();
+            if start < end {
+                tokens.push(LexicalToken { start, end, token });
+            }
         }
         Ok(tokens)
-    }
-
-    fn next_source_token(&mut self) -> Result<Option<LexicalToken>> {
-        self.skip_whitespace();
-        if self.pos >= self.chars.len() {
-            return Ok(None);
-        }
-
-        let start = self.pos;
-        let (token, char_count) = self.scan_token()?;
-        self.pos += char_count;
-        Ok(Some(LexicalToken { start, end: self.pos, token }))
     }
 
     fn add_token_cross_line(&mut self, tok: &Token) {

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -3,6 +3,7 @@ use crate::token::LitKind;
 use crate::token::Operator;
 use crate::token::Token;
 use crate::Error;
+use crate::LexicalToken;
 
 use std::fs;
 use std::path::Path;
@@ -195,6 +196,26 @@ impl Scanner {
         self.pos += char_count;
         self.semicolon = self.try_insert_semicolon(&tok);
         Ok(Some((current, tok)))
+    }
+
+    pub(crate) fn tokenize(mut self) -> Result<Vec<LexicalToken>> {
+        let mut tokens = Vec::new();
+        while let Some(token) = self.next_source_token()? {
+            tokens.push(token);
+        }
+        Ok(tokens)
+    }
+
+    fn next_source_token(&mut self) -> Result<Option<LexicalToken>> {
+        self.skip_whitespace();
+        if self.pos >= self.chars.len() {
+            return Ok(None);
+        }
+
+        let start = self.pos;
+        let (token, char_count) = self.scan_token()?;
+        self.pos += char_count;
+        Ok(Some(LexicalToken { start, end: self.pos, token }))
     }
 
     fn add_token_cross_line(&mut self, tok: &Token) {

--- a/tests/tokenize.rs
+++ b/tests/tokenize.rs
@@ -1,0 +1,26 @@
+use gosyn::token::{Operator, Token};
+use gosyn::{tokenize_source, LexicalToken};
+
+fn token_text(source: &str, token: &LexicalToken) -> String {
+    source
+        .chars()
+        .skip(token.start)
+        .take(token.end - token.start)
+        .collect()
+}
+
+#[test]
+fn returns_source_backed_scalar_ranges_without_implicit_semicolons() {
+    let source = "package café\nvalue := 1";
+    let tokens = tokenize_source(source).unwrap();
+    let text = tokens
+        .iter()
+        .map(|token| token_text(source, token))
+        .collect::<Vec<_>>();
+
+    assert_eq!(text, ["package", "café", "value", ":=", "1"]);
+    assert_eq!((tokens[1].start, tokens[1].end), (8, 12));
+    assert!(tokens
+        .iter()
+        .all(|token| token.token != Token::Operator(Operator::SemiColon)));
+}

--- a/tests/tokenize.rs
+++ b/tests/tokenize.rs
@@ -1,4 +1,3 @@
-use gosyn::token::{Operator, Token};
 use gosyn::{tokenize_source, LexicalToken};
 
 fn token_text(source: &str, token: &LexicalToken) -> String {
@@ -10,17 +9,14 @@ fn token_text(source: &str, token: &LexicalToken) -> String {
 }
 
 #[test]
-fn returns_source_backed_scalar_ranges_without_implicit_semicolons() {
-    let source = "package café\nvalue := 1";
+fn returns_scalar_ranges_and_filters_scanner_inserted_semicolons() {
+    let source = "package café;\nvalue := 1";
     let tokens = tokenize_source(source).unwrap();
     let text = tokens
         .iter()
         .map(|token| token_text(source, token))
         .collect::<Vec<_>>();
 
-    assert_eq!(text, ["package", "café", "value", ":=", "1"]);
+    assert_eq!(text, ["package", "café", ";", "value", ":=", "1"]);
     assert_eq!((tokens[1].start, tokens[1].end), (8, 12));
-    assert!(tokens
-        .iter()
-        .all(|token| token.token != Token::Operator(Operator::SemiColon)));
 }


### PR DESCRIPTION
## Summary

Expose lexical tokens with Unicode scalar source ranges through `tokenize_source`.

Whitespace and scanner-inserted semicolons are omitted. Parser behavior remains unchanged.

## Testing

- `cargo test --all-features`

## Related issues

- Close: #17 